### PR TITLE
add: Case insensitive checked_regex

### DIFF
--- a/src/task.js
+++ b/src/task.js
@@ -4,7 +4,7 @@
 'use strict';
 
 const base_regex = /- +\[.] +/;
-const checked_regex = /- +\[x] +.+/;
+const checked_regex = /- +\[x] +.+/i;
 const choice_regex = /Choice(#.+)?/;
 const comment_regex = /<!--.*-->/;
 const options_regex = /<!-- +.+ +-->/;


### PR DESCRIPTION
We encountered a case where one of our colleagues used uppercased `[X]`:
- [x] x
- [X] X

Markdown converts it as checked. Thus, I think it would be a good addition to this project.
Didn't test though 🙂

Bonus: I appreciate the speed of the workflow on CI 🎉  because for many of other projects it takes half minute for build only.